### PR TITLE
Set linkStyle inside TreeChartCore constructor

### DIFF
--- a/packages/tree-chart-core/src/tree-chart/index.ts
+++ b/packages/tree-chart-core/src/tree-chart/index.ts
@@ -56,6 +56,7 @@ export default class TreeChartCore {
     this.treeContainer = params.treeContainer;
     this.dataset = this.updatedInternalData(params.dataset);
     if (params.direction) this.direction = params.direction;
+    if (params.linkStyle) this.linkStyle = params.linkStyle
   }
 
   init() {


### PR DESCRIPTION
Without this change,  setting `linkStyle` prop in VueTree component doesn't change anything as it's passed to constructor but constructor doesn't do anything with it.  